### PR TITLE
Remove "internal build" flag from win32

### DIFF
--- a/starboard/win/win32/args.gn
+++ b/starboard/win/win32/args.gn
@@ -16,4 +16,3 @@ target_platform = "win-win32"
 target_os = "win"
 target_cpu = "x64"
 is_clang = false
-is_internal_build = true


### PR DESCRIPTION
This seems like an old left-over, not needed. It prevents win build from just working on a clean new checkout.

b/216640044